### PR TITLE
Fix Meta.abstract usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ from django_fsm import FSMField
 
 from django_fsm_freeze.models import FreezableFSMModelMixin
 
-class MyDjangoFSMModel(FreezableFSMModelMixin, models.Model):
+class MyDjangoFSMModel(FreezableFSMModelMixin):
 
     # In this example, when object is in the 'active' state, it is immutable.
     FROZEN_IN_STATES = ('active', )

--- a/django_fsm_freeze/models.py
+++ b/django_fsm_freeze/models.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 from dirtyfields import DirtyFieldsMixin
 from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.db import models
 from django.db.models.signals import class_prepared
 from django.dispatch import receiver
 
@@ -10,7 +11,7 @@ class FreezeValidationError(ValidationError):
     pass
 
 
-class FreezableFSMModelMixin(DirtyFieldsMixin):
+class FreezableFSMModelMixin(DirtyFieldsMixin, models.Model):
     class Meta:
         abstract = True
 

--- a/mytest/models.py
+++ b/mytest/models.py
@@ -12,9 +12,7 @@ class FakeStates(Enum):
     ARCHIVED = 'archived'
 
 
-class FakeModel(FreezableFSMModelMixin, models.Model):
-    class Meta:
-        abstract = False
+class FakeModel(FreezableFSMModelMixin):
 
     FROZEN_IN_STATES = (
         FakeStates.ACTIVE.value,


### PR DESCRIPTION
For the Meta.abstract property to work as expected, we need the mixin to inherit from models.Model