### PR TITLE
Support `bypass_fsm_freeze` on class level

### DIFF
--- a/django_fsm_freeze/models.py
+++ b/django_fsm_freeze/models.py
@@ -22,7 +22,7 @@ def bypass_fsm_freeze(
 ):
     if objs and not isinstance(objs, Iterable):
         objs = (objs,)
-    errors = list()
+    errors = []
     for obj in objs:
         if not isinstance(obj, FreezableFSMModelMixin):
             errors.append(

--- a/django_fsm_freeze/models.py
+++ b/django_fsm_freeze/models.py
@@ -35,13 +35,13 @@ def bypass_fsm_freeze(
 
     try:
         if bypass_globally is True:
-            setattr(FreezableFSMModelMixin, '_DISABLED_FSM_FREEZE', True)
+            FreezableFSMModelMixin._DISABLED_FSM_FREEZE = True
         for obj in objs:
             obj._bypass_fsm_freeze = True
         yield
     finally:
         if bypass_globally is True:
-            setattr(FreezableFSMModelMixin, '_DISABLED_FSM_FREEZE', False)
+            FreezableFSMModelMixin._DISABLED_FSM_FREEZE = False
         for obj in objs:
             obj._bypass_fsm_freeze = False
 


### PR DESCRIPTION
A new argument `bypass_globally` can be passin in as a flag to disable (bypass) fsm freeze check on the class level.
Can be used in combination with `objs`  argument.